### PR TITLE
`addReducer` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ in a single page app, or to initalize the state of a new store.  It will result 
 
 Replaces all reducers registered with this store.
 
+#### `<Store>.addReducer(type, reducerFunc)`
+
+Adds a reducer for an action type.
+
 ---
 
 ### `bindActionCreators(actionCreators, dispatch)`

--- a/src/create-store.js
+++ b/src/create-store.js
@@ -15,6 +15,9 @@ export function createStore (reducers, initialState) {
 		subscribe: function subscribe (listener) {
 			return store.subscribe(listener);
 		},
+		addReducer: function addReducer (type, reducer) {
+			return store.addReducer(type, reducer);
+		},
 		replaceReducers: function replaceReducers (reducers) {
 			return store.replaceReducers();
 		},

--- a/src/store.js
+++ b/src/store.js
@@ -70,6 +70,10 @@ export class Store {
 		};
 	}
 
+	addReducer (type, fnc) {
+		this[_reducers][type] = fnc;
+	}
+
 	replaceReducers (reducers) {
 		this[_reducers] = reducers || {};
 


### PR DESCRIPTION
It is nice to be able to add reducers to an existing store.  For example, in the [hermes](https://github.com/StreamMeDev/hermes) example I want to use the default store, but then add my two custom suggestion reducers.

Thoughts?